### PR TITLE
update example so Users view listens to changes

### DIFF
--- a/examples/WithSwiftUI/WithSwiftUI/ContentView.swift
+++ b/examples/WithSwiftUI/WithSwiftUI/ContentView.swift
@@ -41,9 +41,13 @@ struct ContentView : View {
                 user.save()
             })
         }.onAppear {
-            self.dataSource.onChanged { (_, snapshot) in
-                self.users = snapshot.after
-            }.get()
+            self.dataSource
+                .onChanged { (_, snapshot) in
+                    self.users = snapshot.after
+                }
+                .sorted(by: { $0.createdAt > $1.createdAt })
+                .get()
+                .listen()
         }
     }
 

--- a/examples/WithSwiftUI/WithSwiftUI/ContentView.swift
+++ b/examples/WithSwiftUI/WithSwiftUI/ContentView.swift
@@ -46,7 +46,6 @@ struct ContentView : View {
                     self.users = snapshot.after
                 }
                 .sorted(by: { $0.createdAt > $1.createdAt })
-                .get()
                 .listen()
         }
     }


### PR DESCRIPTION
Hi, thought it might be helpful if the example WithSwiftUI was extended a bit as I'm learning more about Ballcap. There is one issue that still needs fixing though, and I'd love your thoughts on best way to fix:

If you tap on a user and edit their name, after clicking save UserView correctly shows the updates. The app running on a separate iPhone in the Users (ContentView) or UserView will also show the updates correctly. However, if on the iPhone where the edit was made you go back to the Users list, the list still shows the previous state of the name property, prior to the edit. I'll look at the code more closely, but if you had any thoughts on your preferred way to fix this bug, please let me know.

Thank you for your effort to code up such a nice library.

Kimon